### PR TITLE
Add std::wstring support for HD44780 display

### DIFF
--- a/include/rpi-hw/display/hd44780-inl.hpp
+++ b/include/rpi-hw/display/hd44780-inl.hpp
@@ -102,6 +102,13 @@ hd44780::write( const std::u32string &text, uint8_t flags ) {
 }
 
 inline void
+hd44780::write( const std::wstring &text, uint8_t flags ) {
+
+    // Align the text and write it on the display
+    write( utils::align( text, m_width, flags ) );
+}
+
+inline void
 hd44780::write( uint8_t x, uint8_t y, const std::u32string &text ) {
 
 	// Set the position of the cursor on the display
@@ -112,6 +119,16 @@ hd44780::write( uint8_t x, uint8_t y, const std::u32string &text ) {
 }
 
 inline void
+hd44780::write( uint8_t x, uint8_t y, const std::wstring &text ) {
+
+    // Set the position of the cursor on the display
+    move( x, y );
+
+    // Write the unicode string on the display
+    write( text );
+}
+
+inline void
 hd44780::write( uint8_t x, uint8_t y, const std::u32string &text, uint8_t flags ) {
 
 	// Set the position of the cursor on the display
@@ -119,6 +136,16 @@ hd44780::write( uint8_t x, uint8_t y, const std::u32string &text, uint8_t flags 
 
 	// Write the unicode string on the display
 	write( text, flags );
+}
+
+inline void
+hd44780::write( uint8_t x, uint8_t y, const std::wstring &text, uint8_t flags ) {
+
+    // Set the position of the cursor on the display
+    move( x, y );
+
+    // Write the unicode string on the display
+    write( text, flags );
 }
 
 inline void

--- a/include/rpi-hw/display/hd44780.hpp
+++ b/include/rpi-hw/display/hd44780.hpp
@@ -248,12 +248,25 @@ public:
 	*/
 	void write( const std::u32string &text );
 
+    /*!
+        @brief Writes a unicode string on the display.
+        @param[in] text The unicode string to be written.
+    */
+    void write( const std::wstring &text );
+
 	/*!
 		@brief Writes a unicode string on the display.
 		@param[in] text The string to be written.
 		@param[in] flags The parameters of the text.
 	*/
-	void write( const std::u32string &text, uint8_t flags );
+    void write( const std::u32string &text, uint8_t flags );
+
+    /*!
+        @brief Writes a unicode string on the display.
+        @param[in] text The string to be written.
+        @param[in] flags The parameters of the text.
+    */
+    void write( const std::wstring &text, uint8_t flags );
 
 	/*!
 		@brief Moves the cursor position and writes a unicode string on the display.
@@ -263,6 +276,14 @@ public:
 	*/
 	void write( uint8_t x, uint8_t y, const std::u32string &text );
 
+    /*!
+        @brief Moves the cursor position and writes a unicode string on the display.
+        @param[in] x The new horizontal position of the cursor.
+        @param[in] y The new vertical position of the cursor.
+        @param[in] text The unicode string to be written.
+    */
+    void write( uint8_t x, uint8_t y, const std::wstring &text );
+
 	/*!
 		@brief Moves the cursor position and writes a unicode string on the display.
 		@param[in] x The new horizontal position of the cursor.
@@ -271,6 +292,15 @@ public:
 		@param[in] flags The parameters of the text.
 	*/
 	void write( uint8_t x, uint8_t y, const std::u32string &text, uint8_t flags );
+
+    /*!
+        @brief Moves the cursor position and writes a unicode string on the display.
+        @param[in] x The new horizontal position of the cursor.
+        @param[in] y The new vertical position of the cursor.
+        @param[in] text The unicode string to be written.
+        @param[in] flags The parameters of the text.
+    */
+    void write( uint8_t x, uint8_t y, const std::wstring &text, uint8_t flags );
 
 	/*!
 		@brief Scrolls the contents of the display to the left.

--- a/src/display/hd44780.cpp
+++ b/src/display/hd44780.cpp
@@ -275,7 +275,23 @@ hd44780::write( const std::u32string &text ) {
 
 			default: { write( encode_char_a00( c ) ); break; }
 		}
-	}
+    }
+}
+
+void rpihw::display::hd44780::write(const std::wstring &text)
+{
+    // Write the string on the display
+    for ( auto &c : text ) {
+
+        // Encode the character and put it on the display
+        switch ( m_rom_code ) {
+
+            case ROM_A00: { write( encode_char_a00( c ) ); break; }
+            case ROM_A02: { write( encode_char_a02( c ) ); break; }
+
+            default: { write( encode_char_a00( c ) ); break; }
+        }
+    }
 }
 
 void


### PR DESCRIPTION
For easy usage with Qt or other libraries, its nice to write `std::wstring`s directly.
